### PR TITLE
Ergänzung

### DIFF
--- a/liedersammlung.txt
+++ b/liedersammlung.txt
@@ -3,4 +3,4 @@ Hier können wir Lieder sammeln, die zu Umwelt- und Klimaschutz, FridaysForFutur
 1. Unter dem Pflaster
 2. Und trotzdem Weiter ("Es gibt schon tausend Lieder...")
 3. Das Regenbogenlied
-4. 
+4. Klimaleugner*innen


### PR DESCRIPTION
Klimaleugnen-Lied des Singekreises Mitteldeutschland: https://www.vcp.de/pfadfinden/wp-content/uploads/2020/04/Liedblatt_Klimaleugnen.pdf